### PR TITLE
Upgrade to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.2.2 (2023-05-02)
+
+Implement the Ecto.Type.embed_as/1 callback to eliminate warnings and properly
+dump to an encrypted value when used in embeds.
+
 ## v0.2.1 (2021-07-11)
 
 Add compatibility with OTP 24 (it should continue to work just fine with OTP <24)

--- a/lib/ecto_types/encrypted_string.ex
+++ b/lib/ecto_types/encrypted_string.ex
@@ -23,6 +23,8 @@ defmodule EctoCrypto.EctoTypes.EncryptedBinary do
     value |> to_string |> Aes.encrypt
   end
 
+  def embed_as(_), do: :dump
+
   def load(value) do
     Aes.decrypt(value)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EctoCrypto.MixProject do
   def project do
     [
       app: :ecto_crypto,
-      version: "0.2.1",
+      version: "0.2.2",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Implement the Ecto.Type.embed_as/1 callback to eliminate warnings and properly dump to an encrypted value when used in embeds.